### PR TITLE
Fixes situation bandwidth prevents higher channel configuration

### DIFF
--- a/src/pairing_manager.cpp
+++ b/src/pairing_manager.cpp
@@ -215,11 +215,6 @@ void PairingManager::parse_buffer(std::string& cmd, ConfigMicrohardState& state,
     } else if (state == ConfigMicrohardState::POWER && check_at_result(output)) {
       cmd = "AT+MWTXPOWER=" + power + "\n";
       output = "";
-      state = ConfigMicrohardState::FREQUENCY;
-    } else if (state == ConfigMicrohardState::FREQUENCY && check_at_result(output)) {
-      cmd = "AT+MWFREQ=" + channel + "\n";
-      output = "";
-      std::cout << timestamp() << "Set Microhard channel: " << channel << std::endl;
       state = ConfigMicrohardState::BANDWIDTH;
     } else if (state == ConfigMicrohardState::BANDWIDTH && check_at_result(output)) {
       std::string mh_model_bandwidth = bandwidth;
@@ -233,6 +228,11 @@ void PairingManager::parse_buffer(std::string& cmd, ConfigMicrohardState& state,
       cmd = "AT+MWBAND=" + mh_model_bandwidth + "\n";
       output = "";
       std::cout << timestamp() << "Set Microhard bandwidth: " << mh_model_bandwidth << std::endl;
+      state = ConfigMicrohardState::FREQUENCY;
+    } else if (state == ConfigMicrohardState::FREQUENCY && check_at_result(output)) {
+      cmd = "AT+MWFREQ=" + channel + "\n";
+      output = "";
+      std::cout << timestamp() << "Set Microhard channel: " << channel << std::endl;
       state = ConfigMicrohardState::NETWORK_ID;
     } else if (state == ConfigMicrohardState::NETWORK_ID && check_at_result(output)) {
       cmd = "AT+MWNETWORKID=" + network_id + "\n";

--- a/src/pairing_manager_test.cpp
+++ b/src/pairing_manager_test.cpp
@@ -100,16 +100,16 @@ TEST(pairing_manager_test, parse_buffer) {
   pairing_manager.parse_buffer(cmd, state, buffer4, n, config_pwd, modem_name, new_modem_ip, encryption_key, network_id, channel, bandwidth,
                                power);
   EXPECT_EQ("AT+MWTXPOWER=" + power + "\n", cmd);
-  EXPECT_EQ(ConfigMicrohardState::FREQUENCY, state);
-
-  pairing_manager.parse_buffer(cmd, state, buffer4, n, config_pwd, modem_name, new_modem_ip, encryption_key, network_id, channel, bandwidth,
-                               power);
-  EXPECT_EQ("AT+MWFREQ=" + channel + "\n", cmd);
   EXPECT_EQ(ConfigMicrohardState::BANDWIDTH, state);
 
   pairing_manager.parse_buffer(cmd, state, buffer4, n, config_pwd, modem_name, new_modem_ip, encryption_key, network_id, channel, bandwidth,
                                power);
   EXPECT_EQ("AT+MWBAND=" + bandwidth + "\n", cmd);
+  EXPECT_EQ(ConfigMicrohardState::FREQUENCY, state);
+
+  pairing_manager.parse_buffer(cmd, state, buffer4, n, config_pwd, modem_name, new_modem_ip, encryption_key, network_id, channel, bandwidth,
+                               power);
+  EXPECT_EQ("AT+MWFREQ=" + channel + "\n", cmd);
   EXPECT_EQ(ConfigMicrohardState::NETWORK_ID, state);
 
   pairing_manager.parse_buffer(cmd, state, buffer4, n, config_pwd, modem_name, new_modem_ip, encryption_key, network_id, channel, bandwidth,


### PR DESCRIPTION
if bandwidth before the configuration is 1 MHz and configuration frequency is high - like channel 57,
if you set the channel first, the modem errors and the application doesn't recover, but if you set the bandwidth before the channel it works.