### PR TITLE
Fix for bandwidth error when frequency is our of range on DDL1800 modems

### DIFF
--- a/src/pairing_manager.cpp
+++ b/src/pairing_manager.cpp
@@ -215,6 +215,14 @@ void PairingManager::parse_buffer(std::string& cmd, ConfigMicrohardState& state,
     } else if (state == ConfigMicrohardState::POWER && check_at_result(output)) {
       cmd = "AT+MWTXPOWER=" + power + "\n";
       output = "";
+      if (_system_summary.find("DDL1800") != std::string::npos) {
+        state = ConfigMicrohardState::DEFAULT_FREQUENCY;
+      } else {
+        state = ConfigMicrohardState::BANDWIDTH;
+      }
+    } else if (state == ConfigMicrohardState::DEFAULT_FREQUENCY && check_at_result(output)) {
+      cmd = "AT+MWFREQ=15\n";
+      output = "";
       state = ConfigMicrohardState::BANDWIDTH;
     } else if (state == ConfigMicrohardState::BANDWIDTH && check_at_result(output)) {
       std::string mh_model_bandwidth = bandwidth;

--- a/src/pairing_manager.h
+++ b/src/pairing_manager.h
@@ -59,6 +59,7 @@ enum class ConfigMicrohardState {
   MODEM_CHECK_NAME,
   MODEM_IP,
   POWER,
+  DEFAULT_FREQUENCY,
   FREQUENCY,
   BANDWIDTH,
   NETWORK_ID,


### PR DESCRIPTION
DDL1800 modems fail to set bandwidth if frequency is out of range.
To fix this we set frequency to default before setting bandwidth.