### PR TITLE
Flush stream and sync filesystem

### DIFF
--- a/src/pairing_manager.cpp
+++ b/src/pairing_manager.cpp
@@ -1032,8 +1032,11 @@ bool PairingManager::write_json_gcs_file(std::string filename, Json::Value& val,
     std::cout << timestamp() << "Failed to write to file " << filename << std::endl;
     res = false;
   }
+  out.flush();
   out.close();
 
+  sync();
+  
   return res;
 }
 


### PR DESCRIPTION
In testing we found that powering down the drone can cause the json
files to be zero bytes when the drone is powered back on again.  This
causes the drone to not know what radio settings to set.  The flush and
sync force the file to be written to disk and powering down the drone
and powering it back on again the file is always there on disk.